### PR TITLE
Allow srcdoc and point dependencies to itself

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,22 +8,9 @@ environment:
 
 dependencies:
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-  flutter_html_all:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      path: packages/flutter_html_all
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../
   flutter:
     sdk: flutter
-
-dependency_overrides:
-  flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
 
 dev_dependencies:
   flutter_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,15 +4,26 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter_html:
-    path: ..
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
   flutter_html_all:
-    path: ../packages/flutter_html_all
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      path: packages/flutter_html_all
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
   flutter:
     sdk: flutter
+
+dependency_overrides:
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
 
 dev_dependencies:
   flutter_test:
@@ -20,7 +31,6 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 flutter:
-
   uses-material-design: true
 
   assets:

--- a/packages/flutter_html_all/pubspec.yaml
+++ b/packages/flutter_html_all/pubspec.yaml
@@ -13,45 +13,19 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   flutter_html_audio:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_audio
+    path: ../flutter_html_audio
   flutter_html_iframe:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_iframe
+    path: ../flutter_html_iframe
   flutter_html_math:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_math
+    path: ../flutter_html_math
   flutter_html_svg:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_svg
+    path: ../flutter_html_svg
   flutter_html_table:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_table
+    path: ../flutter_html_table
   flutter_html_video:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
-      path: packages/flutter_html_video
-
-dependency_overrides:
-  flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../flutter_html_video
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_all/pubspec.yaml
+++ b/packages/flutter_html_all/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_all
 description: All optional flutter_html widgets, bundled into a single package.
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -10,14 +11,47 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  flutter_html_audio: ^3.0.0-beta.2
-  flutter_html_iframe: ^3.0.0-beta.2
-  flutter_html_math: ^3.0.0-beta.2
-  flutter_html_svg: ^3.0.0-beta.2
-  flutter_html_table: ^3.0.0-beta.2
-  flutter_html_video: ^3.0.0-beta.2
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  flutter_html_audio:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_audio
+  flutter_html_iframe:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_iframe
+  flutter_html_math:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_math
+  flutter_html_svg:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_svg
+  flutter_html_table:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_table
+  flutter_html_video:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+      path: packages/flutter_html_video
+
+dependency_overrides:
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_audio/pubspec.yaml
+++ b/packages/flutter_html_audio/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_audio
 description: This extension package allows the <audio> tag to be rendered using the flutter_html package
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -10,9 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  video_player: '>=2.2.8 <3.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  video_player: ">=2.2.8 <3.0.0"
   chewie_audio: ^1.5.0
 
 dev_dependencies:

--- a/packages/flutter_html_audio/pubspec.yaml
+++ b/packages/flutter_html_audio/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   video_player: ">=2.2.8 <3.0.0"
   chewie_audio: ^1.5.0
 

--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -33,6 +35,17 @@ class IframeWidget extends StatelessWidget {
         double.tryParse(extensionContext.attributes['width'] ?? "");
     final givenHeight =
         double.tryParse(extensionContext.attributes['height'] ?? "");
+
+    Uri? srcUri;
+    if (extensionContext.attributes['srcdoc'] != null) {
+      srcUri = Uri.dataFromString(
+        extensionContext.attributes['srcdoc'] ?? '',
+        mimeType: 'text/html',
+        encoding: Encoding.getByName('utf-8'),
+      );
+    } else {
+      srcUri = Uri.tryParse(extensionContext.attributes['src'] ?? "") ?? Uri();
+    }
 
     return SizedBox(
       width: givenWidth ?? (givenHeight ?? 150) * 2,

--- a/packages/flutter_html_iframe/pubspec.yaml
+++ b/packages/flutter_html_iframe/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_iframe
 description: This extension package allows the <iframe> tag to be rendered using the flutter_html package
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -10,9 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  webview_flutter: '>=4.0.0 <5.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  webview_flutter: ">=4.0.0 <5.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_iframe/pubspec.yaml
+++ b/packages/flutter_html_iframe/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   webview_flutter: ">=4.0.0 <5.0.0"
 
 dev_dependencies:

--- a/packages/flutter_html_math/pubspec.yaml
+++ b/packages/flutter_html_math/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   flutter_math_fork: ">=0.6.0 <1.0.0"
 
 dev_dependencies:

--- a/packages/flutter_html_math/pubspec.yaml
+++ b/packages/flutter_html_math/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_math
 description: This extension package allows the <math> tag to be rendered using the flutter_html package
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -10,9 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  flutter_math_fork: '>=0.6.0 <1.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  flutter_math_fork: ">=0.6.0 <1.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_svg/pubspec.yaml
+++ b/packages/flutter_html_svg/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_svg
 description: This extension package allows the <svg> tag and svg-based img sources to be rendered using the flutter_html package
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -10,9 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  flutter_svg: '>=1.0.0 <3.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  flutter_svg: ">=1.0.0 <3.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_svg/pubspec.yaml
+++ b/packages/flutter_html_svg/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   flutter_svg: ">=1.0.0 <3.0.0"
 
 dev_dependencies:

--- a/packages/flutter_html_table/pubspec.yaml
+++ b/packages/flutter_html_table/pubspec.yaml
@@ -3,6 +3,7 @@ description: This extension package allows the <table> tag to be rendered using 
 
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -11,9 +12,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  flutter_layout_grid: '>=1.0.1 <3.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  flutter_layout_grid: ">=1.0.1 <3.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_table/pubspec.yaml
+++ b/packages/flutter_html_table/pubspec.yaml
@@ -14,9 +14,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   flutter_layout_grid: ">=1.0.1 <3.0.0"
 
 dev_dependencies:

--- a/packages/flutter_html_video/pubspec.yaml
+++ b/packages/flutter_html_video/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
     sdk: flutter
   html: ">=0.15.0 <1.0.0"
   flutter_html:
-    git:
-      url: https://github.com/KQED/flutter_html.git
-      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+    path: ../..
   video_player: ">=2.2.8 <3.0.0"
   chewie: ">=1.1.0 <2.0.0"
 

--- a/packages/flutter_html_video/pubspec.yaml
+++ b/packages/flutter_html_video/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_html_video
 description: This extension package allows the <video> tag to be rendered using the flutter_html package
 version: 3.0.0-beta.2
 homepage: https://github.com/Sub6Resources/flutter_html
+publish_to: none # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -10,10 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-beta.2
-  video_player: '>=2.2.8 <3.0.0'
-  chewie: '>=1.1.0 <2.0.0'
+  html: ">=0.15.0 <1.0.0"
+  flutter_html:
+    git:
+      url: https://github.com/KQED/flutter_html.git
+      ref: allow-srcdoc-and-point-dependencies-to-kqed-repo
+  video_player: ">=2.2.8 <3.0.0"
+  chewie: ">=1.1.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR allows us to use srcdoc with HTML 

It also updates the dependencies to point at this package rather than the git repo