### PR TITLE
Add null check in style.dart and css_parser.dart

### DIFF
--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -671,8 +671,10 @@ Style? inlineCssToStyle(String? inlineStyle, OnCssParseError? errorHandler) {
     return declarationsToStyle(declarations["*"]!);
   } else if (errorHandler != null) {
     String? newCss = errorHandler.call(inlineStyle ?? "", errors);
-    return inlineCssToStyle(newCss, errorHandler);
+    if (newCss != null) {
+      return inlineCssToStyle(newCss, errorHandler);
     }
+  }
   return null;
 }
 
@@ -687,8 +689,10 @@ Map<String, Map<String, List<css.Expression>>> parseExternalCss(
     return DeclarationVisitor().getDeclarations(sheet);
   } else if (errorHandler != null) {
     String? newCss = errorHandler.call(css, errors);
-    return parseExternalCss(newCss, errorHandler);
+    if (newCss != null) {
+      return parseExternalCss(newCss, errorHandler);
     }
+  }
   return {};
 }
 

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -561,7 +561,9 @@ class Style {
 extension _MarginRelativeValues on Margin {
   Margin? getRelativeValue(double remValue, double emValue) {
     double? calculatedValue = calculateRelativeValue(remValue, emValue);
-    return Margin(calculatedValue);
+    if (calculatedValue != null) {
+        return Margin(calculatedValue);
+    }
   
     return null;
   }
@@ -570,8 +572,9 @@ extension _MarginRelativeValues on Margin {
 extension _PaddingRelativeValues on HtmlPadding {
   HtmlPadding? getRelativeValue(double remValue, double emValue) {
     double? calculatedValue = calculateRelativeValue(remValue, emValue);
-    return HtmlPadding(calculatedValue);
-  
+    if (calculatedValue != null) {
+      return HtmlPadding(calculatedValue);
+    }
     return null;
   }
 }


### PR DESCRIPTION
Some null checks were removed in a previous commit. This change adds those null checks back.